### PR TITLE
Update readme for return value sequences

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ A summary of functions:
 Function | Description
 ---|---
 `createSpy SPY`                 | Create a new spy, or reset an existing spy
-`createSpy -r RETURN_VAL SPY`   | Sets the return value of the spy when invoked
+`createSpy -r RETURN_VAL SPY`   | Sets the return value of the spy when invoked<br>Can be passed multiple times to set a return value sequence<br>Once the sequence finishes, the last value is always returned
 `createSpy -o OUTPUT SPY`       | Sets output via standard output when the spy is invoked<br>When used with `-e`, standard out is written to first
 `createSpy -e OUTPUT SPY`       | Sets output via standard error when the spy is invoked<br>When used with `-o`, standard out is written to first
 `createStub SPY`                | Alias for `createSpy`

--- a/shpy
+++ b/shpy
@@ -13,7 +13,7 @@ createSpy() {
         case "$opt" in
             o) output="$OPTARG" ;;
             e) error_output="$OPTARG" ;;
-            r) val="$OPTARG" ;;
+            r) val="$val $OPTARG" ;;
             *) shpy_die "Error: Unknown option -$OPTARG" ;;
         esac
     done
@@ -214,9 +214,22 @@ _shpySpySetReturnValue() {
 
 _shpySpyGetReturnValue() {
     # shellcheck disable=SC2039
-    local val
-    eval val="\$_shpy_${name}_val"
-    return "${val:-0}"
+    local values count current_value
+    eval values="\$_shpy_${name}_val"
+    count=$(getSpyCallCount "$name")
+
+    # $values is a space separated array. Iterate
+    # $count times to set $current_value to the right entry.
+    # If $count is greater than the number of return values,
+    # $current_value is set to the last return value.
+    for value in ${values:-0}; do
+      current_value=$value
+
+      count=$(( count - 1 ))
+      [ $count -eq 0 ] && break
+    done
+
+    return "$current_value"
 }
 
 ##### External Interface #####

--- a/t/test_createSpy
+++ b/t/test_createSpy
@@ -67,6 +67,23 @@ testShouldResetStubReturnValue() {
     assertTrue 'dosomething returns the default -- success' $?
 }
 
+testShouldStubMultipleReturnValues() {
+    createSpy -r 2 -r 1 -r 0 dosomething || fail 'createSpy dosomething'
+
+    dosomething
+    assertEquals 'first return value equals first passed val' 2 $?
+
+    dosomething
+    assertEquals 'second return value equals second passed val' 1 $?
+
+    dosomething
+    assertEquals 'third return value equals third passed val' 0 $?
+
+    dosomething
+    assertEquals 'subsequent return values equal last passed val' 0 $?
+}
+
+
 testShouldStubOutput() {
     # shellcheck disable=SC2039
     local output


### PR DESCRIPTION
You can now pass `-r` multiple times to establish return value sequences. This closes #3 

```bash
createSpy -r 0 -r 1 -r 2 mySpy
mySpy # 0
mySpy # 1
mySpy # 2
mySpy # 2
```