### PR TITLE
Support nounset

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,11 +1,11 @@
 REPO_ROOT=$(shell git rev-parse --show-toplevel)
 DOCKER_FLAGS=-it --rm -e SHUNIT_COLOR=always
 
-DOCKER_DEBIAN=debian:latest
-DOCKER_ZSH=imwithye/zsh:latest
-DOCKER_CHECKBASHISMS=manabu/checkbashisms-docker:latest
+DOCKER_DEBIAN=debian:buster-20190708-slim
+DOCKER_ZSH=zshusers/zsh:5.7.1
+DOCKER_CHECKBASHISMS=manabu/checkbashisms-docker:0.1.0
 DOCKER_SHELLCHECK=koalaman/shellcheck:latest
-DOCKER_KCOV=ragnaroek/kcov:v33
+DOCKER_KCOV=kcov/kcov:v36
 
 TESTS=$(wildcard t/test_*)
 APP_TESTS=$(addprefix /app/, $(TESTS))
@@ -44,9 +44,9 @@ test_zsh: docker_installed
 ifeq (, $(shell docker images -q $(DOCKER_ZSH)))
 	@docker pull $(DOCKER_ZSH)
 endif
-	@docker run $(DOCKER_FLAGS) -e SHELL=/bin/zsh \
-		--mount type=bind,source=$(REPO_ROOT),target=/rootfs,readonly \
-		$(DOCKER_ZSH) /bin/zsh -o shwordsplit -c /rootfs/t/run_tests
+	@docker run $(DOCKER_FLAGS) -e SHELL=/usr/bin/zsh -w /app \
+		--mount type=bind,source=$(REPO_ROOT),target=/app \
+		$(DOCKER_ZSH) /usr/bin/zsh -o shwordsplit -c /app/t/run_tests
 
 lint: docker_installed
 ifeq (, $(shell docker images -q $(DOCKER_CHECKBASHISMS)))

--- a/shpy
+++ b/shpy
@@ -150,7 +150,7 @@ cleanupSpies() {
 }
 
 _shpyInit() {
-    if [ -n "$_shpy_inited" ]; then
+    if [ -n "${_shpy_inited+is_set}" ]; then
         return
     fi
 
@@ -264,7 +264,7 @@ _shpySpyPrintOutput() {
         call_index=$((call_index - 1))
     done
 
-    if [ -n "$output" ]; then
+    if [ -n "${output+is_set}" ]; then
         printf '%s' "$output"
     fi
 }
@@ -287,7 +287,7 @@ _shpySpyPrintErrorOutput() {
         call_index=$((call_index - 1))
     done
 
-    if [ -n "$error_output" ]; then
+    if [ -n "${error_output+is_set}" ]; then
         printf '%s' "$error_output" 1>&2
     fi
 }

--- a/t/run_tests
+++ b/t/run_tests
@@ -1,13 +1,18 @@
 #!/bin/sh
 
+set -o nounset
+
 if "$SHELL" --version >/dev/null 2>&1; then
   printf '%s\n' "$($SHELL --version)"
 else
   printf '%s\n' "$SHELL"
 fi
 
-[ "$USE_KCOV" ] && \
+if [ "${USE_KCOV+is_set}" ]; then
   test_runner="kcov $(dirname "$0")/../coverage --exclude-path=$(dirname "$0")"
+else
+  test_runner=''
+fi
 
 for test_file in "$(dirname "$0")"/test_*; do
   printf '\nRunning %s...\n' "$(basename "$test_file")"


### PR DESCRIPTION
This resolves #12 and sets `nounset` during testing to put stricter requirements on `shpy` 