### PR TITLE
Support spies in subshells

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -66,6 +66,8 @@ assertEquals 'unexpected spy output' 'hello world' "$(helloSpy)"
 
 Tests should verify the expected _stdout_, expected _stderr_, and expected _return value_, even if the expected output is nothing. In some cases it may make sense to omit some of these tests, and that's perfectly ok!
 
+If your test involves calling a spy, you should create a second test case for the same condition that runs the spy in a new shell with `runInNewShell`. This ensures shpy works for sourced _and_ executed scripts
+
 The `assertDies` function is provided for tests that expect `shpy_die` to be called. This function takes the command to run as a string, an optional expected death message, and an optional expected exit status:
 
 ```sh
@@ -76,6 +78,15 @@ The `doOrDie` function is provided to fail a test if the given code returns a no
 
 ```sh
 doOrDie createSpy mySpy
+```
+
+The `runInNewShell` function is provided to run a command in a new process of the parent shell. This is useful to simulate shell scripts that are executed rather than sourced:
+
+```sh
+runInNewShell mySpy --some --args
+
+# To preserve argument whitespace, you may need to wrap your command in quotes
+runInNewShell 'mySpy --message "hello world" file1 file2'
 ```
 
 ### Running Tests

--- a/Dockerfile
+++ b/Dockerfile
@@ -21,6 +21,9 @@ RUN apk --no-cache add \
 # Create a non-root `shpy` user
 RUN addgroup -S shpy && adduser -S shpy -G shpy
 
+# Define the shpy path globally
+ENV SHPY_PATH /shpy/shpy
+
 # Copy in shellcheck and shunit2
 COPY --from=shellcheck --chown=shpy /bin/shellcheck /usr/local/bin/shellcheck
 COPY --from=shunit --chown=shpy /shunit2/shunit2 /usr/local/bin/shunit2

--- a/README.md
+++ b/README.md
@@ -23,9 +23,14 @@ If you'd like to help with shpy's development, or just gain a better understandi
 
 ## API
 
-To use **shpy** in your tests, source the `shpy` script:
+To use **shpy** in your tests, set `SHPY_PATH` to the location of `shpy` and source the script:
 
-	. path/to/shpy
+```
+SHPY_PATH=path/to/shpy
+export SHPY_PATH
+
+. path/to/shpy
+```
 	
 A summary of functions:
 

--- a/README.md
+++ b/README.md
@@ -31,6 +31,8 @@ export SHPY_PATH
 
 . path/to/shpy
 ```
+
+When using the Docker image, `SHPY_PATH` is preset as `/shpy/shpy` for convenience
 	
 A summary of functions:
 

--- a/shpy
+++ b/shpy
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env sh
 
 # Ensure SHPY_PATH is set
 if [ -z "${SHPY_PATH:+is_set_and_not_null}" ]; then

--- a/shpy
+++ b/shpy
@@ -339,16 +339,25 @@ _shpySpyGetReturnValue() {
 
 ##### External Interface #####
 
+# Break path caching to ensure spies come first in the path
+_shpy_break_path_cache() {
+    PATH="$PATH"
+    export PATH
+}
+
 shpy_make_temp_dir() {
-    command mktemp -d shpy.XXXXXX
+    command -p mktemp -d shpy.XXXXXX
+    _shpy_break_path_cache
 }
 
 shpy_ensure_dir() {
-    command mkdir -p -- "$1"
+    command -p mkdir -p -- "$1"
+    _shpy_break_path_cache
 }
 
 shpy_remove_dir_tree() {
-    command rm -rf -- "$1"
+    command -p rm -rf -- "$1"
+    _shpy_break_path_cache
 }
 
 shpy_die() {

--- a/shpy
+++ b/shpy
@@ -1,5 +1,11 @@
 #!/bin/sh
 
+# Ensure SHPY_PATH is set
+if [ -z "${SHPY_PATH:+is_set_and_not_null}" ]; then
+  printf 'Error: SHPY_PATH is not set as the path to shpy\n' >&2
+  return 1
+fi
+
 createSpy() {
     if [ $# -eq 0 ]; then
         echo 'Usage: spy SPY_NAME'
@@ -162,6 +168,10 @@ cleanupSpies() {
     fi
 
     if [ -n "${_shpy_spies_dir+is_set}" ]; then
+      # Remove the shpy bin directory from the path using parameter expansion
+      PATH="${PATH%$_shpy_spies_dir/bin:*}${PATH#*$_shpy_spies_dir/bin:}"
+      export PATH
+
       find "$_shpy_spies_dir" -maxdepth 1 -type f -exec sh -c '_shpyResetSpy "$1"' _ {} \;
 
       shpy_remove_dir_tree "$_shpy_spies_dir" || shpy_die "Error: \`shpy_remove_dir_tree '$_shpy_spies_dir'\` failed"
@@ -177,6 +187,15 @@ _shpyInit() {
 
     _shpy_inited=1
     _shpy_spies_dir=$(shpy_make_temp_dir) || shpy_die "Error: \`shpy_make_temp_dir\` failed"
+
+    # Ensure child shell processes have access to these variables
+    export _shpy_inited
+    export _shpy_spies_dir
+
+    # Create the shpy bin directory and prepend it to the path
+    shpy_ensure_dir "$_shpy_spies_dir/bin/"
+    PATH="$_shpy_spies_dir/bin:$PATH"
+    export PATH
 }
 
 _shpyResetSpy() {
@@ -189,7 +208,15 @@ _shpyResetSpy() {
 }
 
 _shpyInjectSpyFunction() {
-    eval "$1() { _shpyRunSpy '$1' \"\$@\"; }"
+    # shellcheck disable=SC2039
+    local spy_file
+
+    spy_file="$_shpy_spies_dir/bin/$1"
+
+    printf '#!/usr/bin/env sh\n' > "$spy_file"
+    printf '. %s\n' "$SHPY_PATH" >> "$spy_file"
+    printf '_shpyRunSpy "%s" "$@"\n' "$1" >> "$spy_file"
+    chmod +x "$spy_file"
 }
 
 _shpyGetSpyCurent() {
@@ -201,6 +228,7 @@ _shpyGetSpyCurent() {
 
 _shpySetSpyCurent() {
     eval "_shpy_$1_current=$2"
+    eval export "_shpy_$1_current"
 }
 
 _shpyGetDirectoryContentsCount() {
@@ -315,6 +343,7 @@ _shpySpyPrintErrorOutput() {
 
 _shpySpySetReturnValue() {
     eval "_shpy_${1}_val=\$2"
+    eval export "_shpy_${1}_val"
 }
 
 _shpySpyGetReturnValue() {

--- a/shpy
+++ b/shpy
@@ -157,10 +157,16 @@ examineNextSpyCall() {
 }
 
 cleanupSpies() {
+    if [ -n "${_shpy_inited+is_set}" ]; then
+      unset -v _shpy_inited
+    fi
+
     if [ -n "${_shpy_spies_dir+is_set}" ]; then
       find "$_shpy_spies_dir" -maxdepth 1 -type f -exec sh -c '_shpyResetSpy "$1"' _ {} \;
 
       shpy_remove_dir_tree "$_shpy_spies_dir" || shpy_die "Error: \`shpy_remove_dir_tree '$_shpy_spies_dir'\` failed"
+
+      unset -v _shpy_spies_dir
     fi
 }
 
@@ -171,16 +177,6 @@ _shpyInit() {
 
     _shpy_inited=1
     _shpy_spies_dir=$(shpy_make_temp_dir) || shpy_die "Error: \`shpy_make_temp_dir\` failed"
-}
-
-_shpyDeinit() {
-    if [ -n "${_shpy_inited+is_set}" ]; then
-      unset -v _shpy_inited
-    fi
-
-    if [ -n "${_shpy_spies_dir+is_set}" ]; then
-      unset -v _shpy_spies_dir
-    fi
 }
 
 _shpyResetSpy() {

--- a/shpy-shunit2
+++ b/shpy-shunit2
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env sh
 
 assertCallCount() {
     if [ $# -lt 2 ] || [ $# -gt 3 ]; then

--- a/test/run_tests
+++ b/test/run_tests
@@ -10,6 +10,12 @@ test_directory=$(CDPATH='' cd -- "$(dirname -- "$0")" && pwd -P)
 readonly ANSI_COLOR_PATTERN="$(printf '\\(\033\[[0-9];[0-9]\+m\\)\\?')"
 export ANSI_COLOR_PATTERN
 
+# Determine the current shell executable by parsing the current process info
+# Ignore shellcheck's recommendation to use pgrep, as it may not be available
+# shellcheck disable=SC2009
+SHELL="$(ps -e | grep -Eo "\b$$\b.+[0-9:.]+\s+\S+\b")"
+SHELL="${SHELL##* }"
+
 #
 # Testcase discovery function
 #
@@ -39,6 +45,12 @@ assertDies() {
 # $1... - Code to execute or fail from
 doOrDie() {
     "$@" || fail "Failed to execute \`$*\`"
+}
+
+# Runs the given command in a new process of the parent shell
+# $1... - Command to execute
+runInNewShell() {
+  $SHELL -c "$*"
 }
 
 #

--- a/test/run_tests
+++ b/test/run_tests
@@ -75,6 +75,10 @@ tearDown() {
   cleanupSpies
 }
 
+# Define the path to shpy
+SHPY_PATH="$test_directory/../shpy"
+export SHPY_PATH
+
 # Source shpy and shunit2 to begin running tests
 # shellcheck source=/dev/null
 . "$test_directory/../shpy"

--- a/test/run_tests
+++ b/test/run_tests
@@ -70,10 +70,9 @@ suite() {
   done
 }
 
-# Clean up spies and call the private deinitialization function after each test
+# Clean up spies after each test
 tearDown() {
   cleanupSpies
-  _shpyDeinit
 }
 
 # Source shpy and shunit2 to begin running tests

--- a/test/run_tests
+++ b/test/run_tests
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env sh
 
 # Disallow unset variables in tests
 set -o nounset

--- a/test/test_createSpy
+++ b/test/test_createSpy
@@ -267,3 +267,23 @@ itResetsCallCountWhenRecreatingSpy() {
 
     assertEquals 'call count was not reset' 0 "$(getSpyCallCount dosomething)"
 }
+
+# This tests exists so kcov can see what is covered by the spy scripts
+itSupportsSourcingSpies() {
+    doOrDie createSpy -o 'hello' -e 'world' -o 'goodnight' -e 'moon' dosomething
+
+    # Set arguments for the sourced spy
+    set -- arg1 arg2
+
+    # shellcheck source=/dev/null
+    assertEquals 'first call output was not stubbed' 'helloworld' "$(. "${_shpy_spies_dir:-shpy dir is not set}/bin/dosomething" 2>&1)"
+
+    # shellcheck source=/dev/null
+    assertEquals 'second call output was not stubbed' 'goodnightmoon' "$(. "${_shpy_spies_dir:-shpy dir is not set}/bin/dosomething" 2>&1)"
+
+    # shellcheck source=/dev/null
+    assertEquals 'third call output was not stubbed' 'goodnightmoon' "$(. "${_shpy_spies_dir:-shpy dir is not set}/bin/dosomething" 2>&1)"
+
+    wasSpyCalledWith dosomething arg1 arg2
+    assertTrue 'args were not recorded' $?
+}

--- a/test/test_createSpy
+++ b/test/test_createSpy
@@ -31,6 +31,13 @@ itStubsReturnValueOfCreatedSpy() {
     assertEquals 'return value was not stubbed' 123 $?
 }
 
+itStubsReturnValueOfCreatedSpyInNewShell() {
+    doOrDie createSpy -r 123 dosomething
+
+    runInNewShell dosomething
+    assertEquals 'return value was not stubbed in new shell' 123 $?
+}
+
 itStubsReturnValuesPerSpy() {
     doOrDie createSpy -r 1 dosomething
     doOrDie createSpy -r 2 domore
@@ -39,6 +46,16 @@ itStubsReturnValuesPerSpy() {
     assertEquals 'dosomething did not return the stubbed value' 1 $?
     domore
     assertEquals 'domore did not return the stubbed value' 2 $?
+}
+
+itStubsReturnValuesPerSpyInNewShell() {
+    doOrDie createSpy -r 1 dosomething
+    doOrDie createSpy -r 2 domore
+
+    runInNewShell dosomething
+    assertEquals 'dosomething did not return the stubbed value in new shell' 1 $?
+    runInNewShell domore
+    assertEquals 'domore did not return the stubbed value in new shell' 2 $?
 }
 
 itStubsMultipleReturnValuesAsSequence() {
@@ -57,6 +74,22 @@ itStubsMultipleReturnValuesAsSequence() {
     assertEquals 'subsequent return values are not the last stubbed value' 0 $?
 }
 
+itStubsMultipleReturnValuesAsSequenceInNewShell() {
+    doOrDie createSpy -r 2 -r 1 -r 0 dosomething
+
+    runInNewShell dosomething
+    assertEquals 'first return value is not the first stubbed value in new shell' 2 $?
+
+    runInNewShell dosomething
+    assertEquals 'second return value is not the second stubbed value in new shell' 1 $?
+
+    runInNewShell dosomething
+    assertEquals 'third return value is not the third stubbed value in new shell' 0 $?
+
+    runInNewShell dosomething
+    assertEquals 'subsequent return values are not the last stubbed value in new shell' 0 $?
+}
+
 itResetsStubbedReturnValueWhenRecreatingSpy() {
     doOrDie createSpy -r 123 dosomething
 
@@ -69,6 +102,11 @@ itResetsStubbedReturnValueWhenRecreatingSpy() {
 itStubsOutputOfCreatedSpy() {
     doOrDie createSpy -o "$(printf 'some\noutput')" dosomething
     assertEquals 'output was not stubbed' "$(printf 'some\noutput')" "$(dosomething)"
+}
+
+itStubsOutputOfCreatedSpyInNewShell() {
+    doOrDie createSpy -o "$(printf 'some\noutput')" dosomething
+    assertEquals 'output was not stubbed in new shell' "$(printf 'some\noutput')" "$(runInNewShell dosomething)"
 }
 
 itStubsMultipleOutputsAsSequence() {
@@ -89,6 +127,24 @@ itStubsMultipleOutputsAsSequence() {
     assertEquals 'subsequent output is not the last stubbed value' "$third_output" "$(dosomething)"
 }
 
+itStubsMultipleOutputsAsSequenceInNewShell() {
+    # shellcheck disable=SC2039
+    local first_output second_output third_output
+    first_output=$(printf "%s\\n%s" "first" "output")
+    second_output="second OUTPUT"
+    third_output="$(printf 'Third\nOutput')"
+
+    doOrDie createSpy -o "$first_output" -o "$second_output" -o "$third_output" dosomething
+  
+    assertEquals 'first output is not the first stubbed value in new shell' "$first_output" "$(runInNewShell dosomething)"
+
+    assertEquals 'second output is not the second stubbed value in new shell' "$second_output" "$(runInNewShell dosomething)"
+
+    assertEquals 'third output is not the third stubbed value in new shell' "$third_output" "$(runInNewShell dosomething)"
+
+    assertEquals 'subsequent output is not the last stubbed value in new shell' "$third_output" "$(runInNewShell dosomething)"
+}
+
 itResetsStubbedOutputWhenRecreatingSpy() {
     doOrDie createSpy -o 'some output' dosomething
 
@@ -99,6 +155,11 @@ itResetsStubbedOutputWhenRecreatingSpy() {
 itStubsErrorOutputOfCreatedSpy() {
     doOrDie createSpy -e "$(printf 'some\noutput')" dosomething
     assertEquals 'error output was not stubbed' "$(printf 'some\noutput')" "$(dosomething 2>&1 >/dev/null)"
+}
+
+itStubsErrorOutputOfCreatedSpyInNewShell() {
+    doOrDie createSpy -e "$(printf 'some\noutput')" dosomething
+    assertEquals 'error output was not stubbed in new shell' "$(printf 'some\noutput')" "$(runInNewShell dosomething 2>&1 >/dev/null)"
 }
 
 itStubsMultipleErrorOutputsAsSequence() {
@@ -117,6 +178,24 @@ itStubsMultipleErrorOutputsAsSequence() {
     assertEquals 'third error output is not the third stubbed value' "$third_output" "$(dosomething 2>&1 >/dev/null)"
 
     assertEquals 'subsequent error output is not the last stubbed value' "$third_output" "$(dosomething 2>&1 >/dev/null)"
+}
+
+itStubsMultipleErrorOutputsAsSequenceInNewShell() {
+    # shellcheck disable=SC2039
+    local first_output second_output third_output
+    first_output=$(printf "%s\\n%s" "first" "output")
+    second_output="second OUTPUT"
+    third_output="$(printf 'Third\nOutput')"
+
+    doOrDie createSpy -e "$first_output" -e "$second_output" -e "$third_output" dosomething
+  
+    assertEquals 'first error output is not the first stubbed value in new shell' "$first_output" "$(runInNewShell dosomething 2>&1 >/dev/null)"
+
+    assertEquals 'second error output is not the second stubbed value in new shell' "$second_output" "$(runInNewShell dosomething 2>&1 >/dev/null)"
+
+    assertEquals 'third error output is not the third stubbed value in new shell' "$third_output" "$(runInNewShell dosomething 2>&1 >/dev/null)"
+
+    assertEquals 'subsequent error output is not the last stubbed value in new shell' "$third_output" "$(runInNewShell dosomething 2>&1 >/dev/null)"
 }
 
 itResetsStubbedErrorOutputWhenRecreatingSpy() {

--- a/test/test_createSpy
+++ b/test/test_createSpy
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env sh
 
 itDisplaysUsageWhenCreatingSpyWithoutArgs() {
     assertEquals 'usage message was not displayed' 'Usage: spy SPY_NAME' "$(createSpy 2>&1)"

--- a/test/test_createStub
+++ b/test/test_createStub
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env sh
 
 itCreatesSpyWhenCreateStubIsCalled() {
     doOrDie createStub dosomething

--- a/test/test_examineNextSpyCall
+++ b/test/test_examineNextSpyCall
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env sh
 
 itDisplaysUsageWhenExaminingNextCallWithoutArgs() {
     assertEquals 'usage message was not displayed' 'Usage: examineNextSpyCall SPY' "$(examineNextSpyCall 2>&1)"

--- a/test/test_examineNextSpyCall
+++ b/test/test_examineNextSpyCall
@@ -47,9 +47,29 @@ itDisplaysErrorWhenCheckingIfSpyWasCalledAfterExamingNextCallOnLastCall() {
     assertTrue 'output begins with "Error:"' $?
 }
 
+itDisplaysErrorWhenCheckingIfSpyWasCalledAfterExamingNextCallOnLastCallInNewShell() {
+    doOrDie createSpy dosomething
+    runInNewShell dosomething
+
+    examineNextSpyCall dosomething >/dev/null
+
+    printf '%s' "$(wasSpyCalledWith dosomething 2>&1  >/dev/null)" | grep -q '^Error:'
+    assertTrue 'output begins with "Error:" from new shell' $?
+}
+
 itReturns1WhenCheckingIfSpyWasCalledAfterExamingNextCallOnLastCall() {
     doOrDie createSpy dosomething
     dosomething
+
+    examineNextSpyCall dosomething
+    wasSpyCalledWith dosomething >/dev/null 2>&1
+
+    assertEquals 1 $?
+}
+
+itReturns1WhenCheckingIfSpyWasCalledAfterExamingNextCallOnLastCallInNewShell() {
+    doOrDie createSpy dosomething
+    runInNewShell dosomething
 
     examineNextSpyCall dosomething
     wasSpyCalledWith dosomething >/dev/null 2>&1
@@ -64,10 +84,25 @@ itChecksTheNextCallWhenExamingNextSpyCall() {
     dosomething somearg
 
     wasSpyCalledWith dosomething
-    assertTrue "checking first spy call with no args gave wrong result" $?
+    assertTrue 'checking first spy call with no args gave wrong result' $?
 
     examineNextSpyCall dosomething
     wasSpyCalledWith dosomething somearg
 
-    assertTrue "checking second spy call with args gave wrong result" $?
+    assertTrue 'checking second spy call with args gave wrong result' $?
+}
+
+itChecksTheNextCallWhenExamingNextSpyCallInNewShell() {
+    doOrDie createSpy dosomething
+
+    runInNewShell dosomething
+    runInNewShell dosomething somearg
+
+    wasSpyCalledWith dosomething
+    assertTrue 'checking first spy call with no args gave wrong result in new shell' $?
+
+    examineNextSpyCall dosomething
+    wasSpyCalledWith dosomething somearg
+
+    assertTrue 'checking second spy call with args gave wrong result in new shell' $?
 }

--- a/test/test_getArgsForCall
+++ b/test/test_getArgsForCall
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env sh
 
 itDisplaysUsageWhenGettingCallArgsWithoutArgs() {
     assertEquals 'usage message was not displayed' 'Usage: getArgsForCall SPY CALL_NUMBER' "$(getArgsForCall 2>&1)"

--- a/test/test_getArgsForCall
+++ b/test/test_getArgsForCall
@@ -50,9 +50,25 @@ itDisplaysErrorWhenGettingCallArgsForInvalidCallNumber() {
     assertTrue 'output does not begin with "Error:"' $?
 }
 
+itDisplaysErrorWhenGettingCallArgsForInvalidCallNumberInNewShell() {
+    doOrDie createSpy someSpy
+    runInNewShell someSpy
+
+    printf '%s\n' "$(getArgsForCall someSpy 999 2>&1 >/dev/null)" | grep -q '^Error:'
+    assertTrue 'output does not begin with "Error:" from new shell' $?
+}
+
 itReturns1WhenGettingCallArgsForInvalidCallNumber() {
     doOrDie createSpy someSpy
     someSpy
+
+    getArgsForCall someSpy 999 >/dev/null 2>&1
+    assertEquals 1 $?
+}
+
+itReturns1WhenGettingCallArgsForInvalidCallNumberInNewShell() {
+    doOrDie createSpy someSpy
+    runInNewShell someSpy
 
     getArgsForCall someSpy 999 >/dev/null 2>&1
     assertEquals 1 $?
@@ -68,6 +84,16 @@ itOutputsNothingWhenGettingCallArgsForCallWithoutArgs() {
     assertEquals 'output is not empty for call without args' '' "$(getArgsForCall someSpy 2 2>&1)"
 }
 
+itOutputsNothingWhenGettingCallArgsForCallWithoutArgsInNewShell() {
+    doOrDie createSpy someSpy
+    runInNewShell someSpy
+    runInNewShell someSpy
+
+    assertEquals 'output is not empty for call without args in new shell' '' "$(getArgsForCall someSpy 1 2>&1)"
+
+    assertEquals 'output is not empty for call without args in new shell' '' "$(getArgsForCall someSpy 2 2>&1)"
+}
+
 itReturns0WhenGettingCallArgsForCallWithoutArgs() {
     doOrDie createSpy someSpy
     someSpy
@@ -80,9 +106,28 @@ itReturns0WhenGettingCallArgsForCallWithoutArgs() {
     assertTrue 'second call returned a non-zero status' $?
 }
 
+itReturns0WhenGettingCallArgsForCallWithoutArgsInNewShell() {
+    doOrDie createSpy someSpy
+    runInNewShell someSpy
+    runInNewShell someSpy
+
+    getArgsForCall someSpy 1 >/dev/null 2>&1
+    assertTrue 'first call returned a non-zero status in new shell' $?
+
+    getArgsForCall someSpy 2 >/dev/null 2>&1
+    assertTrue 'second call returned a non-zero status in new shell' $?
+}
+
 itOutputsNoQuotesAroundSingleWordArgsWhenGettingCallArgs() {
     doOrDie createSpy someSpy
     someSpy "foo" bar 'baz'
+
+    assertEquals 'args were not output without quotes' 'foo bar baz' "$(getArgsForCall someSpy 1 2>&1)"
+}
+
+itOutputsNoQuotesAroundSingleWordArgsWhenGettingCallArgsInNewShell() {
+    doOrDie createSpy someSpy
+    runInNewShell someSpy "foo" bar 'baz'
 
     assertEquals 'args were not output without quotes' 'foo bar baz' "$(getArgsForCall someSpy 1 2>&1)"
 }
@@ -96,6 +141,15 @@ itOutputsDoubleQuotesAroundMultiWordArgsWhenGettingCallArgs() {
         "$(getArgsForCall someSpy 1 2>&1)"
 }
 
+itOutputsDoubleQuotesAroundMultiWordArgsWhenGettingCallArgsInNewShell() {
+    doOrDie createSpy someSpy
+    runInNewShell "someSpy \"foo bar\" abc def 'baz bat' \"$(printf "tab\\tinside")\""
+
+    assertEquals 'multi-word args were not output with double quotes in new shell' \
+        "$(printf '"foo bar" abc def "baz bat" "tab\tinside"')" \
+        "$(getArgsForCall someSpy 1 2>&1)"
+}
+
 itOutputsCorrectArgsForCallNumberWhenGettingCallArgs() {
     doOrDie createSpy someSpy
 
@@ -103,9 +157,23 @@ itOutputsCorrectArgsForCallNumberWhenGettingCallArgs() {
     someSpy
     someSpy -a "foo bar" -baz
 
-    assertEquals "incorrect args output for first call" "foo" "$(getArgsForCall someSpy 1 2>&1)"
+    assertEquals 'incorrect args output for first call' "foo" "$(getArgsForCall someSpy 1 2>&1)"
 
-    assertEquals "incorrect args output for second call" '' "$(getArgsForCall someSpy 2 2>&1)"
+    assertEquals 'incorrect args output for second call' '' "$(getArgsForCall someSpy 2 2>&1)"
 
-    assertEquals "incorrect args output for third call" '-a "foo bar" -baz' "$(getArgsForCall someSpy 3 2>&1)"
+    assertEquals 'incorrect args output for third call' '-a "foo bar" -baz' "$(getArgsForCall someSpy 3 2>&1)"
+}
+
+itOutputsCorrectArgsForCallNumberWhenGettingCallArgsInNewShell() {
+    doOrDie createSpy someSpy
+
+    runInNewShell someSpy foo
+    runInNewShell someSpy
+    runInNewShell 'someSpy -a "foo bar" -baz'
+
+    assertEquals 'incorrect args output for first call in new shell' "foo" "$(getArgsForCall someSpy 1 2>&1)"
+
+    assertEquals 'incorrect args output for second call in new shell' '' "$(getArgsForCall someSpy 2 2>&1)"
+
+    assertEquals 'incorrect args output for third call in new shell' '-a "foo bar" -baz' "$(getArgsForCall someSpy 3 2>&1)"
 }

--- a/test/test_getSpyCallCount
+++ b/test/test_getSpyCallCount
@@ -22,6 +22,14 @@ itOutputs1WhenGettingCallCountOfSpyCalledOnce() {
     assertEquals '1' "$(getSpyCallCount dosomething 2>&1)"
 }
 
+itOutputs1WhenGettingCallCountOfSpyCalledOnceInNewShell() {
+    doOrDie createSpy dosomething
+
+    runInNewShell dosomething
+
+    assertEquals '1' "$(getSpyCallCount dosomething 2>&1)"
+}
+
 itOutputs2WhenGettingCallCountOfSpyCalledTwice() {
     doOrDie createSpy dosomething
 
@@ -31,12 +39,13 @@ itOutputs2WhenGettingCallCountOfSpyCalledTwice() {
     assertEquals '2' "$(getSpyCallCount dosomething 2>&1)"
 }
 
-itOutputs1WhenGettingCallCountOfSpyCalledOnceInSubshell() {
+itOutputs2WhenGettingCallCountOfSpyCalledTwiceInNewShell() {
     doOrDie createSpy dosomething
 
-    (dosomething)
+    runInNewShell dosomething
+    runInNewShell dosomething
 
-    assertEquals '1' "$(getSpyCallCount dosomething 2>&1)"
+    assertEquals '2' "$(getSpyCallCount dosomething 2>&1)"
 }
 
 itOutputsCorrectCallCountsForMultipleSpies() {
@@ -47,4 +56,14 @@ itOutputsCorrectCallCountsForMultipleSpies() {
 
     assertEquals 'call count output for wrong spy' '1' "$(getSpyCallCount dosomething 2>&1)"
     assertEquals 'call count output for wrong spy' '0' "$(getSpyCallCount dosomethingelse 2>&1)"
+}
+
+itOutputsCorrectCallCountsForMultipleSpiesInNewShell() {
+    doOrDie createSpy dosomething
+    doOrDie createSpy dosomethingelse
+
+    runInNewShell dosomething
+
+    assertEquals 'call count output for wrong spy in new shell' '1' "$(getSpyCallCount dosomething 2>&1)"
+    assertEquals 'call count output for wrong spy in new shell' '0' "$(getSpyCallCount dosomethingelse 2>&1)"
 }

--- a/test/test_getSpyCallCount
+++ b/test/test_getSpyCallCount
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env sh
 
 itDisplaysUsageWhenGettingCallCountWithoutArgs() {
     assertEquals 'usage message was not displayed' 'Usage: getSpyCallCount SPY' "$(getSpyCallCount 2>&1)"

--- a/test/test_shunit2Interface
+++ b/test/test_shunit2Interface
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env sh
 
 #
 # assertCallCount tests

--- a/test/test_shunit2Interface
+++ b/test/test_shunit2Interface
@@ -5,18 +5,11 @@
 #
 
 itDisplaysUsageWhenAssertCallCountHasTooFewArgs() {
-    doOrDie createSpy dosomething
-    dosomething
-
     assertEquals 'usage message was not displayed' 'Usage: assertCallCount [MESSAGE] SPY COUNT' "$(assertCallCount dosomething 2>&1)"
 }
 
 itReturns1WhenAssertCallCountHasTooFewArgs() {
-    doOrDie createSpy dosomething
-    dosomething
-
     assertCallCount dosomething >/dev/null
-
     assertEquals 1 $?
 }
 
@@ -28,9 +21,25 @@ itDisplaysAssertionWhenAssertCallCountFails() {
     assertTrue 'output does not begin with "ASSERT:"' $?
 }
 
+itDisplaysAssertionWhenAssertCallCountFailsInNewShell() {
+    doOrDie createSpy dosomething
+    runInNewShell dosomething
+
+    printf '%s' "$(assertCallCount dosomething 0)" | grep -q "^${ANSI_COLOR_PATTERN}ASSERT"
+    assertTrue 'output does not begin with "ASSERT:" from new shell' $?
+}
+
 itReturns1WhenAssertCallCountFails() {
     doOrDie createSpy dosomething
     dosomething
+
+    (assertCallCount dosomething 0 >/dev/null)
+    assertEquals 1 $?
+}
+
+itReturns1WhenAssertCallCountFailsInNewShell() {
+    doOrDie createSpy dosomething
+    runInNewShell dosomething
 
     (assertCallCount dosomething 0 >/dev/null)
     assertEquals 1 $?
@@ -97,9 +106,25 @@ itDisplaysAssertionWhenAssertCalledWithFails() {
     assertTrue 'output does not begin with "ASSERT:"' $?
 }
 
+itDisplaysAssertionWhenAssertCalledWithFailsInNewShell() {
+    doOrDie createSpy dosomething
+    runInNewShell dosomething 123
+
+    printf '%s' "$(assertCalledWith dosomething 456 2>/dev/null)" | grep -q "^${ANSI_COLOR_PATTERN}ASSERT"
+    assertTrue 'output does not begin with "ASSERT:" from new shell' $?
+}
+
 itReturns1WhenAssertCalledWithFails() {
     doOrDie createSpy dosomething
     dosomething 123
+
+    (assertCalledWith dosomething 456 >/dev/null)
+    assertEquals 1 $?
+}
+
+itReturns1WhenAssertCalledWithFailsInNewShell() {
+    doOrDie createSpy dosomething
+    runInNewShell dosomething 123
 
     (assertCalledWith dosomething 456 >/dev/null)
     assertEquals 1 $?
@@ -112,9 +137,24 @@ itDisplaysNothingWhenAssertCalledWithPasses() {
     assertEquals 'unexpected output' '' "$(assertCalledWith dosomething 123 1>&2)"
 }
 
+itDisplaysNothingWhenAssertCalledWithPassesInNewShell() {
+    doOrDie createSpy dosomething
+    runInNewShell dosomething 123
+
+    assertEquals 'unexpected output from new shell' '' "$(assertCalledWith dosomething 123 1>&2)"
+}
+
 itReturns0WhenAssertCalledWithPasses() {
     doOrDie createSpy dosomething
     dosomething 123
+
+    assertCalledWith dosomething 123
+    assertEquals 0 $?
+}
+
+itReturns0WhenAssertCalledWithPassesInNewShell() {
+    doOrDie createSpy dosomething
+    runInNewShell dosomething 123
 
     assertCalledWith dosomething 123
     assertEquals 0 $?
@@ -130,6 +170,18 @@ itAdvancesToNextCallAfterAssertCalledWith() {
 
     assertCalledWith dosomething 2
     assertEquals 'second assertion was not for second call' 0 $?
+}
+
+itAdvancesToNextCallAfterAssertCalledWithInNewShell() {
+    doOrDie createSpy dosomething
+    runInNewShell dosomething 1
+    runInNewShell dosomething 2
+
+    assertCalledWith dosomething 1
+    assertEquals 'first assertion was not for first call in new shell' 0 $?
+
+    assertCalledWith dosomething 2
+    assertEquals 'second assertion was not for second call in new shell' 0 $?
 }
 
 #
@@ -153,6 +205,14 @@ itDisplaysAssertionWhenAssertCalledWith_Fails() {
     assertTrue 'output does not begin with "ASSERT:"' $?
 }
 
+itDisplaysAssertionWhenAssertCalledWith_FailsInNewShell() {
+    doOrDie createSpy dosomething
+    runInNewShell dosomething 123
+
+    printf '%s' "$(assertCalledWith_ 'message' dosomething 456 2>/dev/null)" | grep -q "^${ANSI_COLOR_PATTERN}ASSERT"
+    assertTrue 'output does not begin with "ASSERT:" from new shell' $?
+}
+
 itDisplaysMessageWhenAssertCalledWith_Fails() {
     doOrDie createSpy dosomething
     dosomething 123
@@ -161,9 +221,25 @@ itDisplaysMessageWhenAssertCalledWith_Fails() {
     assertTrue 'assertion output does not contain custom message' $?
 }
 
+itDisplaysMessageWhenAssertCalledWith_FailsInNewShell() {
+    doOrDie createSpy dosomething
+    runInNewShell dosomething 123
+
+    printf '%s' "$(assertCalledWith_ 'shpymsg' dosomething 456)" | grep -q "shpymsg"
+    assertTrue 'assertion output does not contain custom message from new shell' $?
+}
+
 itReturns1WhenAssertCalledWith_Fails() {
     doOrDie createSpy dosomething
     dosomething 123
+
+    (assertCalledWith_ 'message' dosomething 456 >/dev/null)
+    assertEquals 1 $?
+}
+
+itReturns1WhenAssertCalledWith_FailsInNewShell() {
+    doOrDie createSpy dosomething
+    runInNewShell dosomething 123
 
     (assertCalledWith_ 'message' dosomething 456 >/dev/null)
     assertEquals 1 $?
@@ -176,9 +252,24 @@ itDisplaysNothingWhenAssertCalledWith_Passes() {
     assertEquals 'unexpected output' '' "$(assertCalledWith_ 'message' dosomething 123)"
 }
 
+itDisplaysNothingWhenAssertCalledWith_PassesInNewShell() {
+    doOrDie createSpy dosomething
+    runInNewShell dosomething 123
+
+    assertEquals 'unexpected output from new shell' '' "$(assertCalledWith_ 'message' dosomething 123)"
+}
+
 itReturns0WhenAssertCalledWith_Passes() {
     doOrDie createSpy dosomething
     dosomething 123
+
+    assertCalledWith_ 'message' dosomething 123
+    assertEquals 0 $?
+}
+
+itReturns0WhenAssertCalledWith_PassesInNewShell() {
+    doOrDie createSpy dosomething
+    runInNewShell dosomething 123
 
     assertCalledWith_ 'message' dosomething 123
     assertEquals 0 $?
@@ -194,6 +285,18 @@ itAdvancesToNextCallAfterAssertCalledWith_() {
 
     assertCalledWith_ 'message' dosomething 2
     assertEquals 'second assertion was not for second call' 0 $?
+}
+
+itAdvancesToNextCallAfterAssertCalledWith_InNewShell() {
+    doOrDie createSpy dosomething
+    runInNewShell dosomething 1
+    runInNewShell dosomething 2
+
+    assertCalledWith_ 'message' dosomething 1
+    assertEquals 'first assertion was not for first call in new shell' 0 $?
+
+    assertCalledWith_ 'message' dosomething 2
+    assertEquals 'second assertion was not for second call in new shell' 0 $?
 }
 
 #
@@ -218,10 +321,28 @@ itDisplaysAssertionWhenAssertCalledOnceWithFails() {
     assertTrue 'output does not begin with "ASSERT:"' $?
 }
 
+itDisplaysAssertionWhenAssertCalledOnceWithFailsInNewShell() {
+    doOrDie createSpy dosomething
+    runInNewShell dosomething 123
+    runInNewShell dosomething 456
+
+    printf '%s' "$(assertCalledOnceWith dosomething 123 2>/dev/null)" | grep -q "^${ANSI_COLOR_PATTERN}ASSERT"
+    assertTrue 'output does not begin with "ASSERT:" from new shell' $?
+}
+
 itReturns1WhenAssertCalledOnceWithFails() {
     doOrDie createSpy dosomething
     dosomething 123
     dosomething 456
+
+    (assertCalledOnceWith dosomething 123 >/dev/null)
+    assertEquals 1 $?
+}
+
+itReturns1WhenAssertCalledOnceWithFailsInNewShell() {
+    doOrDie createSpy dosomething
+    runInNewShell dosomething 123
+    runInNewShell dosomething 456
 
     (assertCalledOnceWith dosomething 123 >/dev/null)
     assertEquals 1 $?
@@ -234,9 +355,24 @@ itDisplaysNothingWhenAssertCalledOnceWithPasses() {
     assertEquals 'unexpected output' '' "$(assertCalledOnceWith dosomething 123 2>&1)"
 }
 
+itDisplaysNothingWhenAssertCalledOnceWithPassesInNewShell() {
+    doOrDie createSpy dosomething
+    runInNewShell dosomething 123
+
+    assertEquals 'unexpected output from new shell' '' "$(assertCalledOnceWith dosomething 123 2>&1)"
+}
+
 itReturns0WhenAssertCalledOnceWithPasses() {
     doOrDie createSpy dosomething
     dosomething 123
+
+    assertCalledOnceWith dosomething 123
+    assertEquals 0 $?
+}
+
+itReturns0WhenAssertCalledOnceWithPassesInNewShell() {
+    doOrDie createSpy dosomething
+    runInNewShell dosomething 123
 
     assertCalledOnceWith dosomething 123
     assertEquals 0 $?
@@ -263,6 +399,14 @@ itDisplaysAssertionWhenAssertCalledOnceWith_Fails() {
     assertTrue 'output does not begin with "ASSERT:"' $?
 }
 
+itDisplaysAssertionWhenAssertCalledOnceWith_FailsInNewShell() {
+    doOrDie createSpy dosomething
+    runInNewShell dosomething 123
+
+    printf '%s' "$(assertCalledOnceWith_ 'message' dosomething 456 2>/dev/null)" | grep -q "^${ANSI_COLOR_PATTERN}ASSERT"
+    assertTrue 'output does not begin with "ASSERT:" from new shell' $?
+}
+
 itDisplaysMessageWhenAssertCalledOnceWith_Fails() {
     doOrDie createSpy dosomething
     dosomething 123
@@ -271,9 +415,25 @@ itDisplaysMessageWhenAssertCalledOnceWith_Fails() {
     assertTrue 'assertion output does not contain custom message' $?
 }
 
+itDisplaysMessageWhenAssertCalledOnceWith_FailsInNewShell() {
+    doOrDie createSpy dosomething
+    runInNewShell dosomething 123
+
+    printf '%s' "$(assertCalledOnceWith_ 'shpymsg' dosomething 456)" | grep -q "shpymsg"
+    assertTrue 'assertion output does not contain custom message from new shell' $?
+}
+
 itReturns1WhenAssertCalledOnceWith_Fails() {
     doOrDie createSpy dosomething
     dosomething 123
+
+    (assertCalledOnceWith_ 'message' dosomething 456 >/dev/null)
+    assertEquals 1 $?
+}
+
+itReturns1WhenAssertCalledOnceWith_FailsInNewShell() {
+    doOrDie createSpy dosomething
+    runInNewShell dosomething 123
 
     (assertCalledOnceWith_ 'message' dosomething 456 >/dev/null)
     assertEquals 1 $?
@@ -286,9 +446,24 @@ itDisplaysNothingWhenAssertCalledOnceWith_Passes() {
     assertEquals 'unexpected output' '' "$(assertCalledOnceWith_ 'message' dosomething 123 2>&1)"
 }
 
+itDisplaysNothingWhenAssertCalledOnceWith_PassesInNewShell() {
+    doOrDie createSpy dosomething
+    runInNewShell dosomething 123
+
+    assertEquals 'unexpected output from new shell' '' "$(assertCalledOnceWith_ 'message' dosomething 123 2>&1)"
+}
+
 itReturns0WhenAssertCalledOnceWith_Passes() {
     doOrDie createSpy dosomething
     dosomething 123
+
+    assertCalledOnceWith_ 'message' dosomething 123
+    assertEquals 0 $?
+}
+
+itReturns0WhenAssertCalledOnceWith_PassesInNewShell() {
+    doOrDie createSpy dosomething
+    runInNewShell dosomething 123
 
     assertCalledOnceWith_ 'message' dosomething 123
     assertEquals 0 $?
@@ -315,9 +490,25 @@ itDisplaysAssertionWhenAssertNeverCalledFails() {
     assertTrue 'output does not begin with "ASSERT:"' $?
 }
 
+itDisplaysAssertionWhenAssertNeverCalledFailsInNewShell() {
+    doOrDie createSpy dosomething
+    runInNewShell dosomething
+
+    printf '%s' "$(assertNeverCalled dosomething 2>/dev/null)" | grep -q "^${ANSI_COLOR_PATTERN}ASSERT"
+    assertTrue 'output does not begin with "ASSERT:" from new shell' $?
+}
+
 itReturns1WhenAssertNeverCalledFails() {
     doOrDie createSpy dosomething
     dosomething
+
+    (assertNeverCalled dosomething >/dev/null)
+    assertEquals 1 $?
+}
+
+itReturns1WhenAssertNeverCalledFailsInNewShell() {
+    doOrDie createSpy dosomething
+    runInNewShell dosomething
 
     (assertNeverCalled dosomething >/dev/null)
     assertEquals 1 $?
@@ -344,6 +535,14 @@ itDisplaysAssertionWhenAssertNeverCalledFailsWithOptionalMessage() {
     assertTrue 'assertion output does not begin with "ASSERT:"' $?
 }
 
+itDisplaysAssertionWhenAssertNeverCalledFailsWithOptionalMessageInNewShell() {
+    doOrDie createSpy dosomething
+    runInNewShell dosomething
+
+    printf '%s' "$(assertNeverCalled "shpymsg" dosomething)" | grep -q "^${ANSI_COLOR_PATTERN}ASSERT"
+    assertTrue 'assertion output does not begin with "ASSERT:" from new shell' $?
+}
+
 itDisplaysOptionalMessageWhenAssertNeverCalledFails() {
     doOrDie createSpy dosomething
     dosomething
@@ -352,9 +551,25 @@ itDisplaysOptionalMessageWhenAssertNeverCalledFails() {
     assertTrue 'assertion output does not contain optional message' $?
 }
 
+itDisplaysOptionalMessageWhenAssertNeverCalledFailsInNewShell() {
+    doOrDie createSpy dosomething
+    runInNewShell dosomething
+
+    printf '%s' "$(assertNeverCalled "shpymsg" dosomething)" | grep -q "shpymsg"
+    assertTrue 'assertion output does not contain optional message from new shell' $?
+}
+
 itReturns1WhenAssertNeverCalledFailsWithOptionalMessage() {
     doOrDie createSpy dosomething
     dosomething
+
+    (assertNeverCalled 'message' dosomething >/dev/null)
+    assertEquals 1 $?
+}
+
+itReturns1WhenAssertNeverCalledFailsWithOptionalMessageInNewShell() {
+    doOrDie createSpy dosomething
+    runInNewShell dosomething
 
     (assertNeverCalled 'message' dosomething >/dev/null)
     assertEquals 1 $?

--- a/test/test_systemCommands
+++ b/test/test_systemCommands
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env sh
 
 itCanStubSystemCommands() {
     doOrDie createSpy touch

--- a/test/test_systemCommands
+++ b/test/test_systemCommands
@@ -10,6 +10,16 @@ itCanStubSystemCommands() {
     assertFalse 'file was created; "touch" was not stubbed' $?
 }
 
+itCanStubSystemCommandsInNewShell() {
+    doOrDie createSpy touch
+    runInNewShell touch nonexistent_file
+
+    assertCalledOnceWith_ 'failed to verify call count and args for system spy in new shell' touch nonexistent_file
+
+    [ -f nonexistent_file ]
+    assertFalse 'file was created; "touch" was not stubbed in new shell' $?
+}
+
 # mkdir is used internally by shpy, so the spy must not be used internally
 itCanStubSystemCommandsUsedByShpy() {
     doOrDie createSpy -r 123 mkdir
@@ -21,4 +31,17 @@ itCanStubSystemCommandsUsedByShpy() {
 
     [ -d nonexistent_dir ]
     assertFalse 'directory was created; "mkdir" was not stubbed' $?
+}
+
+# mkdir is used internally by shpy, so the spy must not be used internally
+itCanStubSystemCommandsUsedByShpyInNewShell() {
+    doOrDie createSpy -r 123 mkdir
+    runInNewShell mkdir -p nonexistent_dir
+
+    assertEquals 'return value was not stubbed in new shell' 123 $?
+
+    assertCalledOnceWith_ 'failed to verify call count and args for system spy in new shell' mkdir -p nonexistent_dir
+
+    [ -d nonexistent_dir ]
+    assertFalse 'directory was created; "mkdir" was not stubbed in new shell' $?
 }

--- a/test/test_testEnvironment
+++ b/test/test_testEnvironment
@@ -8,3 +8,30 @@ itRunsTestsWithNounset() {
 
   assertFalse 'nounset is not set in the test environment' $?
 }
+
+itReturns1WhenShpyPathVariableIsNotSet() {
+    # shellcheck disable=SC2039
+    local original_shpy_path
+    original_shpy_path="$SHPY_PATH"
+    unset SHPY_PATH
+
+    # shellcheck source=/dev/null
+    . "$original_shpy_path"
+    assertEquals 1 $?
+
+    SHPY_PATH="$original_shpy_path"
+    export SHPY_PATH
+}
+
+itDisplaysErrorMessageWhenShpyPathVariableIsNotSet() {
+    # shellcheck disable=SC2039
+    local original_shpy_path
+    original_shpy_path="$SHPY_PATH"
+    unset SHPY_PATH
+
+    # shellcheck source=/dev/null
+    assertEquals 'Error: SHPY_PATH is not set as the path to shpy' "$(. "$original_shpy_path" 2>&1 >/dev/null)"
+
+    SHPY_PATH="$original_shpy_path"
+    export SHPY_PATH
+}

--- a/test/test_testEnvironment
+++ b/test/test_testEnvironment
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env sh
 
 itRunsTestsWithNounset() {
   # if nounset is set, this subshell will exit with a nonzero status

--- a/test/test_wasSpyCalledWith
+++ b/test/test_wasSpyCalledWith
@@ -26,9 +26,24 @@ itDisplaysNothingWhenWasSpyCalledWithPassesWithNoSpyArgs() {
     assertEquals 'unexpected output' '' "$(wasSpyCalledWith dosomething 2>&1)"
 }
 
+itDisplaysNothingWhenWasSpyCalledWithPassesWithNoSpyArgsInNewShell() {
+    doOrDie createSpy dosomething
+    runInNewShell dosomething
+
+    assertEquals 'unexpected output from new shell' '' "$(wasSpyCalledWith dosomething 2>&1)"
+}
+
 itReturns0WhenWasSpyCalledWithPassesWithNoSpyArgs() {
     doOrDie createSpy dosomething
     dosomething
+
+    wasSpyCalledWith dosomething
+    assertEquals 0 $?
+}
+
+itReturns0WhenWasSpyCalledWithPassesWithNoSpyArgsInNewShell() {
+    doOrDie createSpy dosomething
+    runInNewShell dosomething
 
     wasSpyCalledWith dosomething
     assertEquals 0 $?
@@ -41,9 +56,24 @@ itDisplaysNothingWhenWasSpyCalledWithPassesWithOneSpyArg() {
     assertEquals 'unexpected output' '' "$(wasSpyCalledWith dosomething 123 2>&1)"
 }
 
-itReturns0WhenWasSpyCalledWithPassesWithOneSpyArgs() {
+itDisplaysNothingWhenWasSpyCalledWithPassesWithOneSpyArgInNewShell() {
+    doOrDie createSpy dosomething
+    runInNewShell dosomething 123
+
+    assertEquals 'unexpected output from new shell' '' "$(wasSpyCalledWith dosomething 123 2>&1)"
+}
+
+itReturns0WhenWasSpyCalledWithPassesWithOneSpyArg() {
     doOrDie createSpy dosomething
     dosomething 123
+
+    wasSpyCalledWith dosomething 123
+    assertEquals 0 $?
+}
+
+itReturns0WhenWasSpyCalledWithPassesWithOneSpyArgInNewShell() {
+    doOrDie createSpy dosomething
+    runInNewShell dosomething 123
 
     wasSpyCalledWith dosomething 123
     assertEquals 0 $?
@@ -56,9 +86,24 @@ itDisplaysNothingWhenWasSpyCalledWithPassesWithTwoSpyArgs() {
     assertEquals 'unexpected output' '' "$(wasSpyCalledWith dosomething 123 456 2>&1)"
 }
 
+itDisplaysNothingWhenWasSpyCalledWithPassesWithTwoSpyArgsInNewShell() {
+    doOrDie createSpy dosomething
+    runInNewShell dosomething 123 456
+
+    assertEquals 'unexpected output from new shell' '' "$(wasSpyCalledWith dosomething 123 456 2>&1)"
+}
+
 itReturns0WhenWasSpyCalledWithPassesWithTwoSpyArgs() {
     doOrDie createSpy dosomething
     dosomething 123 456
+
+    wasSpyCalledWith dosomething 123 456
+    assertEquals 0 $?
+}
+
+itReturns0WhenWasSpyCalledWithPassesWithTwoSpyArgsInNewShell() {
+    doOrDie createSpy dosomething
+    runInNewShell dosomething 123 456
 
     wasSpyCalledWith dosomething 123 456
     assertEquals 0 $?
@@ -71,9 +116,24 @@ itDisplaysNothingWhenWasSpyCalledWithFailsWithNonexistentSpyArgs() {
     assertEquals 'unexpected output' '' "$(wasSpyCalledWith dosomething 123 2>&1)"
 }
 
+itDisplaysNothingWhenWasSpyCalledWithFailsWithNonexistentSpyArgsInNewShell() {
+    doOrDie createSpy dosomething
+    runInNewShell dosomething
+
+    assertEquals 'unexpected output from new shell' '' "$(wasSpyCalledWith dosomething 123 2>&1)"
+}
+
 itReturns1WhenWasSpyCalledWithPassesWithNonexistentSpyArgs() {
     doOrDie createSpy dosomething
     dosomething
+
+    wasSpyCalledWith dosomething 123
+    assertEquals 1 $?
+}
+
+itReturns1WhenWasSpyCalledWithPassesWithNonexistentSpyArgsInNewShell() {
+    doOrDie createSpy dosomething
+    runInNewShell dosomething
 
     wasSpyCalledWith dosomething 123
     assertEquals 1 $?
@@ -86,9 +146,24 @@ itDisplaysNothingWhenWasSpyCalledWithFailsMatchingEmptyStringToNoArgs() {
     assertEquals 'unexpected output' '' "$(wasSpyCalledWith dosomething 2>&1)"
 }
 
+itDisplaysNothingWhenWasSpyCalledWithFailsMatchingEmptyStringToNoArgsInNewShell() {
+    doOrDie createSpy dosomething
+    runInNewShell dosomething '""'
+
+    assertEquals 'unexpected output from new shell' '' "$(wasSpyCalledWith dosomething 2>&1)"
+}
+
 itReturns1WhenWasSpyCalledWithFailsMatchingEmptyStringToNoArgs() {
     doOrDie createSpy dosomething
     dosomething ''
+
+    wasSpyCalledWith dosomething
+    assertEquals 1 $?
+}
+
+itReturns1WhenWasSpyCalledWithFailsMatchingEmptyStringToNoArgsInNewShell() {
+    doOrDie createSpy dosomething
+    runInNewShell dosomething '""'
 
     wasSpyCalledWith dosomething
     assertEquals 1 $?
@@ -101,9 +176,24 @@ itDisplaysNothingWhenWasSpyCalledWithPassesWithWhitespaceInArgs() {
     assertEquals 'unexpected output' '' "$(wasSpyCalledWith dosomething "$(printf ' line 1\nline 2\n\tline 3\nline 4  ')" 2>&1)"
 }
 
+itDisplaysNothingWhenWasSpyCalledWithPassesWithWhitespaceInArgsInNewShell() {
+    doOrDie createSpy dosomething
+    runInNewShell "dosomething '$(printf ' line 1\nline 2\n\tline 3\nline 4  ')'"
+
+    assertEquals 'unexpected output from new shell' '' "$(wasSpyCalledWith dosomething "$(printf ' line 1\nline 2\n\tline 3\nline 4  ')" 2>&1)"
+}
+
 itReturns0WhenWasSpyCalledWithPassesWithWhitespaceInArgs() {
     doOrDie createSpy dosomething
     dosomething "$(printf ' line 1\nline 2\n\tline 3\nline 4  ')"
+
+    wasSpyCalledWith dosomething "$(printf ' line 1\nline 2\n\tline 3\nline 4  ')"
+    assertEquals 0 $?
+}
+
+itReturns0WhenWasSpyCalledWithPassesWithWhitespaceInArgsInNewShell() {
+    doOrDie createSpy dosomething
+    runInNewShell "dosomething '$(printf ' line 1\nline 2\n\tline 3\nline 4  ')'"
 
     wasSpyCalledWith dosomething "$(printf ' line 1\nline 2\n\tline 3\nline 4  ')"
     assertEquals 0 $?

--- a/test/test_wasSpyCalledWith
+++ b/test/test_wasSpyCalledWith
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env sh
 
 itDisplaysUsageWhenWasSpyCalledWithHasTooFewArgs() {
     assertEquals 'usage message was not displayed' 'Usage: wasSpyCalledWith SPY [ARG]...' "$(wasSpyCalledWith 2>&1)"


### PR DESCRIPTION
This resolves #29, but adds the inconvenience of having to set `SHPY_PATH` before sourcing shpy. The Docker container presets this variable, so some users won't be inconvenienced by this

This opens the gate to adding a practical use example that can be explained briefly in the readme