### PR TITLE
Unset function so spy from PATH can run

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,15 @@ touch my-new-file # outputs "call me once, shame on you" to stdout, returns true
 touch my-new-file # outputs "call me twice, shame on me" to stderr, returns false
 ```
 
+When developing tests for complex functions with long chained calls, source all of them and use spy with -u flag. The flag will unset declared function, so complex functions can be tested with a mix of spies and original functions. 
+
+```sh
+source my_script.sh # contains complex_function that calls file_check and directory_check
+
+createSpy -o 'spy test' -u file_check
+complex_function # complex_function calls file_check, so it will output "spy test". However, without -u createSpy gives a warning that file_check is already declared and complex_function executes declared one instead of spy
+```
+
 When you're done playing with shpy, it's only polite to clean up after yourself
 
 ```sh
@@ -139,6 +148,7 @@ Function | Description
 `createSpy -r status name`      | Sets the status code returned when the spy is invoked<br>Can be passed multiple times to set a return value sequence<br>Once the sequence finishes, the last value is always returned
 `createSpy -o output name`      | Sets output sent to stdout when the spy is invoked<br>Can be passed multiple times to set an output sequence<br>Once the sequence finishes, the last value is always output<br>When used with `-e`, standard out is written to first
 `createSpy -e output name`      | Sets output sent to stderr when the spy is invoked<br>Can be passed multiple times to set an error output sequence<br>Once the sequence finishes, the last value is always output<br>When used with `-o`, standard out is written to first
+`createSpy -u name`             | A flag to unset declared function, so created spy can run instead otherwise declared function takes precedence<br>Function is not restored after test runs
 `createStub name`               | Alias for `createSpy`
 `getSpyCallCount name`          | Outputs the number of invocations of a spy
 `wasSpyCalledWith name [arg ...]` | Returns 0 if the current spy call under examination has the given args

--- a/README.md
+++ b/README.md
@@ -108,7 +108,8 @@ When developing tests for complex functions with long chained calls, source all 
 source my_script.sh # contains complex_function that calls file_check and directory_check
 
 createSpy -o 'spy test' -u file_check
-complex_function # complex_function calls file_check, so it will output "spy test". However, without -u createSpy gives a warning that file_check is already declared and complex_function executes declared one instead of spy
+complex_function # complex_function calls file_check, which is mocked to output "spy test"
+                 # Without -u, createSpy would warn that file_check is already declared and wouldn't be mocked
 ```
 
 When you're done playing with shpy, it's only polite to clean up after yourself

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,7 +13,7 @@ services:
   ash:
     image: shpy:local
     depends_on: [base]
-    command: sh ${CMD:-/shpy/test/run_tests}
+    command: ash ${CMD:-/shpy/test/run_tests}
     volumes:
       - ./:/shpy:ro
   bash:

--- a/shpy
+++ b/shpy
@@ -282,6 +282,10 @@ _shpyCreateSpyExecutable() {
     printf '. %s\n' "$SHPY_PATH" >> "$spy_file"
     printf '_shpyRunSpy "%s" "$@"\n' "$1" >> "$spy_file"
     chmod +x "$spy_file"
+
+    # Make sure spy script from PATH will be called
+    # by doing unset for the function, in case it was sourced
+    unset -f "$1" 2> /dev/null || true
 }
 
 # Outputs the index of the current spy call under examination

--- a/shpy
+++ b/shpy
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/usr/bin/env sh
 
 # Export the shpy version in the environment
 SHPY_VERSION=1.0.0
@@ -289,7 +289,7 @@ _shpyCreateSpyExecutable() {
     chmod +x "$spy_file"
 
     # Check if function exists with spy name
-    if type "$1" | grep -q "is a shell function\|^$1 is a function"; then
+    if [ "$(command -v "$1")" = "$1" ]; then
        echo "Function $1 is declared and will be called instead of spy. Add -u to createSpy to unset it." >&2
     fi
 }

--- a/shpy
+++ b/shpy
@@ -1,4 +1,4 @@
-#!/usr/bin/env sh
+#!/usr/bin/env bash
 
 # Export the shpy version in the environment
 SHPY_VERSION=1.0.0
@@ -17,7 +17,7 @@ createSpy() {
     # shellcheck disable=SC2039
     local usage status_codes outputs_count outputs_dir errors_count errors_dir spy_name
 
-    usage="Usage: createSpy [[-r status] [-o output] [-e output] ...] name
+    usage="Usage: createSpy [[-r status] [-o output] [-e output] [-u] ...] name
 
 Creates new spies and resets existing spies
 
@@ -29,7 +29,8 @@ Options:
   -o    Sets the output sent to stdout when the spy is invoked
         When used with -e, stdout is written to first
   -e    Sets the output sent to stderr when the spy is invoked
-        When used with -o, stdout is written to first"
+        When used with -o, stdout is written to first
+  -u    Flag to unset (remove) declared function named as spy. It will not be restored."
 
     if [ $# -eq 0 ]; then
         printf '%s\n' "$usage"
@@ -56,7 +57,7 @@ Options:
 
     # Parse command line arguments
     OPTIND=1
-    while getopts :o:r:e: opt; do
+    while getopts :o:r:e:u opt; do
         case "$opt" in
             o)
               # Write the contents to the stdout directory
@@ -72,6 +73,10 @@ Options:
               # Append the status code to a space-delimited sequence
               # Add a space when `status_code` isn't null to avoid leading space
               status_codes="${status_codes-}${status_codes:+ }$OPTARG"
+              ;;
+            u)
+              # Unset function
+              unset -f "$spy_name" 2> /dev/null || true
               ;;
             *) _shpy_die "Error: Unknown option -$OPTARG" ;;
         esac
@@ -283,9 +288,10 @@ _shpyCreateSpyExecutable() {
     printf '_shpyRunSpy "%s" "$@"\n' "$1" >> "$spy_file"
     chmod +x "$spy_file"
 
-    # Make sure spy script from PATH will be called
-    # by doing unset for the function, in case it was sourced
-    unset -f "$1" 2> /dev/null || true
+    # Check if function exists with spy name
+    if type "$1" | grep -q "is a shell function\|^$1 is a function"; then
+       echo "Function $1 is declared and will be called instead of spy. Add -u to createSpy to unset it." >&2
+    fi
 }
 
 # Outputs the index of the current spy call under examination

--- a/test/test_createSpy
+++ b/test/test_createSpy
@@ -221,6 +221,18 @@ itDisplaysStandardOutputBeforeErrorOutput() {
       "$(dosomething 2>&1)"
 }
 
+itCallsSpyOnChainedFunction() {
+
+    f1() { echo "Output from locally defined f1"; }
+    f2() { f1; }
+
+    doOrDie createSpy -o 'Output from spy on f1' f1
+
+    assertEquals 'Locally defined function was called instead of spy' \
+      "Output from spy on f1" \
+      "$(f2)"
+}
+
 # Helper method to run the same case with output defined in different orders
 # $1 - 0 to define all stdout before stderr, 1 to interleave the definitions
 do_multiple_outputs_test() {

--- a/test/test_createSpy
+++ b/test/test_createSpy
@@ -2,7 +2,7 @@
 
 itDisplaysUsageWhenCreatingSpyWithoutArgs() {
     assertEquals 'usage message was not displayed' \
-      'Usage: createSpy [[-r status] [-o output] [-e output] ...] name' \
+      'Usage: createSpy [[-r status] [-o output] [-e output] [-u] ...] name' \
       "$(createSpy 2>&1 | head -n1)"
 }
 
@@ -17,7 +17,7 @@ itDiesWhenCreatingSpyWithUnknownOption() {
 
 itDisplaysUsageWhenCreatingSpyWithRequiredArgMissing() {
     assertEquals 'usage message was not displayed' \
-      'Usage: createSpy [[-r status] [-o output] [-e output] ...] name' \
+      'Usage: createSpy [[-r status] [-o output] [-e output] [-u] ...] name' \
       "$(createSpy -r dosomething 2>&1 | head -n1)"
 }
 
@@ -226,11 +226,24 @@ itCallsSpyOnChainedFunction() {
     f1() { echo "Output from locally defined f1"; }
     f2() { f1; }
 
-    doOrDie createSpy -o 'Output from spy on f1' f1
+    doOrDie createSpy -o 'Output from spy on f1' -u f1
 
     assertEquals 'Locally defined function was called instead of spy' \
       "Output from spy on f1" \
       "$(f2)"
+    
+}
+
+itOutputsStderrMsgForDeclaredFunction() {
+
+    f1() { echo "Output from locally defined f1"; }
+    f2() { f1; }
+
+    out="$(doOrDie createSpy -o 'Output from spy on f1' f1 2>&1)"
+    
+    assertEquals 'createSpy did not output warning about declared function' \
+        "Function f1 is declared and will be called instead of spy. Add -u to createSpy to unset it." \
+        "$out"
 }
 
 # Helper method to run the same case with output defined in different orders


### PR DESCRIPTION
Hi,

As you pointed out in #47, locally defined functions take precedence over anything in $PATH. unset seems the most straightforward way to fix it, -f needed otherwise it unhappy when there is no function to unset.

Closes #47