### PR TITLE
Add expected vs. actual in assertCalledWith message

### DIFF
--- a/shpy-shunit2
+++ b/shpy-shunit2
@@ -26,15 +26,22 @@ assertCalledWith() {
     fi
 
     # shellcheck disable=SC2039
-    local status_code
+    local status_code actual_call current_spy_call
 
     wasSpyCalledWith "$@"
     status_code=$?
 
+    actual_call=$1
+    if [ $status_code -ne 0 ]; then
+        current_spy_call=$(( $(_shpyGetCurrentSpyCallIndex "$1") + 1 ))
+        if ! actual_call="$actual_call $(getArgsForCall "$1" "$current_spy_call")" 2>/dev/null; then
+            actual_call='not called'
+        fi
+    fi
+
     examineNextSpyCall "$1"
 
-    assertTrue $status_code
-
+    assertTrue "expected:<$*> but was:<$actual_call>" $status_code
 }
 
 assertCalledWith_() {

--- a/test/test_shunit2Interface
+++ b/test/test_shunit2Interface
@@ -118,6 +118,48 @@ itDisplaysAssertionWhenAssertCalledWithFailsInNewShell() {
     assertTrue 'output does not begin with "ASSERT:" from new shell' $?
 }
 
+itDisplaysExpectedVsActualWhenAssertCalledWithFailsWithDifferentArgs() {
+    doOrDie createSpy dosomething
+    dosomething 123
+
+    printf '%s' "$(assertCalledWith dosomething 456 2>/dev/null)" |
+        grep -q "expected:<dosomething 456> but was:<dosomething 123>"
+    assertTrue 'output does not contain expected vs. actual' $?
+}
+
+itDisplaysExpectedVsActualWhenAssertCalledWithFailsWithDifferentArgsInNewShell() {
+    doOrDie createSpy dosomething
+    runInNewShell dosomething 123
+
+    printf '%s' "$(assertCalledWith dosomething 456 2>/dev/null)" |
+        grep -q "expected:<dosomething 456> but was:<dosomething 123>"
+    assertTrue 'output does not contain expected vs. actual' $?
+}
+
+itDisplaysExpectedVsActualWhenAssertCalledWithFailsWithTooManyCalls() {
+    doOrDie createSpy dosomething
+    dosomething 123
+
+    assertCalledWith dosomething 123
+    assertEquals 'first assertion was not for first call' 0 $?
+
+    printf '%s' "$(assertCalledWith dosomething 456 2>/dev/null)" |
+        grep -q "expected:<dosomething 456> but was:<not called>"
+    assertTrue 'output does not contain expected vs. actual' $?
+}
+
+itDisplaysExpectedVsActualWhenAssertCalledWithFailsWithTooManyCallsInNewShell() {
+    doOrDie createSpy dosomething
+    runInNewShell dosomething 123
+
+    assertCalledWith dosomething 123
+    assertEquals 'first assertion was not for first call' 0 $?
+
+    printf '%s' "$(assertCalledWith dosomething 456 2>/dev/null)" |
+        grep -q "expected:<dosomething 456> but was:<not called>"
+    assertTrue 'output does not contain expected vs. actual' $?
+}
+
 itReturns1WhenAssertCalledWithFails() {
     doOrDie createSpy dosomething
     dosomething 123


### PR DESCRIPTION
Hi there,

I missed a descriptive default error message for the `assertCalledWith` assertion. With this PR it can print:
```
# The difference when the expectation don't match
ASSERT:expected:<dosomething 456> but was:<dosomething 123>
# A not expected call
ASSERT:expected:<dosomething 456> but was:<not called>
```
I have implemented the message in `shpy-unit2` but using a private api of `shpy`. I'm open to ideas on how to implement it differently if only public api usage is desired (maybe examineNextSpyCall can output an index?).


